### PR TITLE
chore: render software version as plain code block

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -36,6 +36,7 @@ body:
       Example:
       Distribution: deepin v20.9
       Package: deepin-example 5.1.4-1
+    render: plain
   validations:
     required: true
 


### PR DESCRIPTION
使用纯文本代码块渲染软件与系统版本信息字段，避免贴内核版本时被自动链接到 `#24` 这个 issue。

效果： https://github.com/peeweep-test/.github/issues/24